### PR TITLE
Ask user about applying the black screen fix patch, if --patches is not specified

### DIFF
--- a/balatromobile/patcher.py
+++ b/balatromobile/patcher.py
@@ -2,8 +2,8 @@ import tomllib
 from pathlib import Path
 from .resources import get_patch, get_artifact, list_patches
 
-DEFAULT_PATCHES = "basic,landscape,no-crt,fps,external-storage,shaders-flames"
-
+DEFAULT_PATCHES = "basic,landscape,fps,external-storage,shaders-flames"
+BLACKSCREEN_PATCHES = "no-crt"
 
 class Patch:
     def __init__(self, patch: dict):


### PR DESCRIPTION
The `no-crt` patch alters the colors of the game, making it look more washed out so, in my opinion, it's not desirable to apply it on devices that do not need it.
With this change, if the `--patches` argument is not specified, the user is asked whether the patch should be applied.