### PR TITLE
Add support for 1.0.1g-FULL

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ balatromobile android Balatro.exe --patches basic,landscape,external-storage
 ```
 
 ## Supported Game Versions
+* `1.0.1g-FULL`
 * `1.0.1f-FULL`
 * `1.0.1e-FULL` (public beta)
 * `1.0.1c-FULL` (public beta)

--- a/balatromobile/patches/basic.toml
+++ b/balatromobile/patches/basic.toml
@@ -4,7 +4,7 @@ supported_platforms = ["android"]
 
 [[patch_lists]]
   version = 0
-  supported_game_versions = ["1.0.1f-FULL", "1.0.1e-FULL", "1.0.1c-FULL"]
+  supported_game_versions = ["1.0.1g-FULL", "1.0.1f-FULL", "1.0.1e-FULL", "1.0.1c-FULL"]
   [[patch_lists.patch_files]]
     target_file = "globals.lua"
     [[patch_lists.patch_files.patches]]


### PR DESCRIPTION
Small update to `basic.toml` and `README.md` to support `1.0.1g-FULL`. No changes to patches were needed, game seems to be playable just as before after a short test.