### PR TITLE
Add GitHub action to publish to PyPi

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,33 @@
+name: Upload Python Package to PyPi
+
+
+on:
+  push:
+    branches:
+      - master # or a pattern like "*" for including all branches
+    paths:
+      - balatromobile/__version__.py
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/balatromobile
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flit
+    - name: Build package
+      run: |
+        flit build
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This is related to #16 

The way this will be working is by detecting changes in `__version__.py`. It will pick up any time that file is changed and upload the new version to PyPi.
If you prefer a different way, such as manually creating a release or a tag would trigger this, let me know and I'll change that.