### PR TITLE
 replace `uber-apk-signer` with `zipalign` and `apksig` 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,5 @@
 *.jar filter=lfs diff=lfs merge=lfs -text
 *.png filter=lfs diff=lfs merge=lfs -text
 *.xcf filter=lfs diff=lfs merge=lfs -text
+zipalign-* filter=lfs diff=lfs merge=lfs -text
+balatromobile/artifacts/uber-debug.keystore filter=lfs diff=lfs merge=lfs -text

--- a/balatromobile/artifacts/apksigner.jar
+++ b/balatromobile/artifacts/apksigner.jar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f24d15016f70bfc85fd70fb41a2f882acbc4e09a385ff0ea4161ccfa8fcb3db
+size 3869836

--- a/balatromobile/artifacts/uber-apk-signer-1.3.0.jar
+++ b/balatromobile/artifacts/uber-apk-signer-1.3.0.jar
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e1299fd6fcf4da527dd53735b56127e8ea922a321128123b9c32d619bba1d835
-size 3208194

--- a/balatromobile/artifacts/uber-debug.keystore
+++ b/balatromobile/artifacts/uber-debug.keystore
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:161a0018f33277e842534f5443fdd36683359b4950f4dc006c1648895cb073b2
+size 2224

--- a/balatromobile/artifacts/zipalign-android-arm64
+++ b/balatromobile/artifacts/zipalign-android-arm64
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de5fab73587010f3cba04e3117045eb7468cec925000f0fea1a52305686b486b
+size 2031937

--- a/balatromobile/artifacts/zipalign-darwin-amd64
+++ b/balatromobile/artifacts/zipalign-darwin-amd64
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:815bc85fb4c2f46ac3cab68298e18ae7723423a11fb5d81c33e77d213c68be09
+size 1863312

--- a/balatromobile/artifacts/zipalign-darwin-arm64
+++ b/balatromobile/artifacts/zipalign-darwin-arm64
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:176c87a0388ae827563f65a124cc282574ae869199eee0943b63590d3ef04e91
+size 1857602

--- a/balatromobile/artifacts/zipalign-linux-amd64
+++ b/balatromobile/artifacts/zipalign-linux-amd64
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7de4a1ce5cfcc0e6472d2190b4690dc26866c53459dc54d1853fb41a3c9c9214
+size 1818776

--- a/balatromobile/artifacts/zipalign-linux-arm64
+++ b/balatromobile/artifacts/zipalign-linux-arm64
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:922b6b17c8fffda2fc9328e604b4a8575f00d6c051c303f0a4b7eb0710062815
+size 1900696

--- a/balatromobile/artifacts/zipalign-windows-amd64
+++ b/balatromobile/artifacts/zipalign-windows-amd64
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5305e50ac97ab6436f220cc7479ad405382a4214a557bb5f8ae95a83ffad57f
+size 1955328

--- a/balatromobile/artifacts/zipalign-windows-arm64
+++ b/balatromobile/artifacts/zipalign-windows-arm64
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9465ddce66e996c3117bb503724ce20b443a253b47b333a69a33980f220ca935
+size 1903616

--- a/balatromobile/resources.py
+++ b/balatromobile/resources.py
@@ -1,6 +1,6 @@
-
 from argparse import Namespace
 import  importlib.resources
+import platform
 from pathlib import Path
 
 def get_resorce(basepath: str | Path, name: str | Path):
@@ -21,10 +21,19 @@ def list_patches() -> list[str]:
         return [f.stem for f in (f / "patches").glob("**/*.toml")]
     
 def all_artifacts():
+    os = platform.system().lower()
+    arch = ({
+        "x86_64": "amd64",
+        "amd64": "amd64",
+        "aarch64": "arm64",
+        "arm64": "arm64",
+    })[platform.machine().lower()]
     return Namespace(
         apk_editor = get_artifact("APKEditor-1.3.7.jar"),
         love_apk = get_artifact("love-11.5-SAF-android-embed.apk"),
-        apk_signer = get_artifact("uber-apk-signer-1.3.0.jar"),
         android_manifest = get_artifact("AndroidManifest.xml"),
         android_res = get_artifact("res"),
+        zipalign = get_artifact(f"zipalign-{os}-{arch}"),
+        uber_keystore = get_artifact("uber-debug.keystore"),
+        apksigner = get_artifact("apksigner.jar"),
     )

--- a/balatromobile/utils.py
+++ b/balatromobile/utils.py
@@ -1,12 +1,22 @@
 import subprocess
+from os import environ
 from pathlib import Path
 
+DEBUG = (debug := environ.get("BALATROMOBILE_DEBUG")) and (debug.lower() != "false")
+
 def run_silent(what: list[str], **kwargs):
+    outpipe = subprocess.DEVNULL
+
+    if DEBUG:
+        from sys import stderr
+        print(f"[DEBUG] `run_silent`: {what=}", file=stderr)
+        outpipe = stderr
+
     subprocess.run(
         what,
         stdin=subprocess.DEVNULL,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        stdout=outpipe,
+        stderr=outpipe,
         check=True,
         **kwargs
     )


### PR DESCRIPTION
fixes #22 

i took `uber-debug.keystore` from Uber APK Signer to maintain support for APKs signed before this change, but Uber APK Signer tries to use a debug key from Android Studio on the user's machine before falling back to its own key, so users of this project that have Android Studio configured will probably get mismatched signature errors.


the precompiled bins in this pr were created with nix flakes on a `linux-amd64` machine:

- apksigner.jar: `nix build nixpkgs/cf577e430899f96e0214a9d83f8f6905922611dd#apksigner && cp result/lib/apksigner.jar .`
- zipalign: `nix build github:janw4ld/zipalign/d250dcbdb098e3e9135d1189d1d5a5e889c4150a && cp result/* .`

